### PR TITLE
Set gems x86 64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'rack-cors'
 gem 'devise'
 gem 'devise-jwt'
 
+gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.4.2)
     puma (5.6.4)
@@ -214,6 +216,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  x86_64-linux
   arm64-darwin-20
   x86_64-darwin-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,9 +216,9 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
-  x86_64-linux
   arm64-darwin-20
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/client.http
+++ b/client.http
@@ -2,7 +2,7 @@ TESTED request
 
 ### Index method
 
-GET http://localhost:4000/api/wine_listings
+GET https://grapevine-rails-api.herokuapp.com/api/wine_listings
 
 ### Successfully creates a wine listing
 ### Response = 201 Created

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:3000"
+    origins "*"
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
- This branch was used for deploying on to Heroku manually. Once merged to main, Heroku deploys from main automatically.
- installed x86_64-linux gem to support mac
- adds gem 'faker' into the Gemfile to help with testing Production environment on Heroku. 'faker' gem from line 33 will need to be removed before submission. It's ok to leave the 'faker' gem in 
```
group :development, :test
```
- migrated the db and seeds over to Heroku for deployment
- Changes the cors setting back to accept all origins to help with local and other domains (Heroku) at the moment. This will change again later when we have netlify set up.
- Deployment on Heroku was successful