### PR TITLE
Setup/admin params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,11 @@
 class ApplicationController < ActionController::API
 
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation])
-    end
+  
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation])
+  end
+
+  
 
 end

--- a/app/controllers/wine_listings_controller.rb
+++ b/app/controllers/wine_listings_controller.rb
@@ -20,25 +20,30 @@ class WineListingsController < ApplicationController
 
   # POST /wine_listings
   def create
-    @wine_listing = WineListing.new(wine_listing_params)
+    if current_user.admin? &&
+      @wine_listing = WineListing.new(wine_listing_params)
 
     # Specify authorisation here.
     # Admin role only function
 
-    if @wine_listing.save
-      render json: @wine_listing, status: :created, location: @wine_listing
+      if @wine_listing.save
+        render json: @wine_listing, status: :created, location: @wine_listing
+      else
+        render json: @wine_listing.errors, status: :unprocessable_entity
+      end
     else
-      render json: @wine_listing.errors, status: :unprocessable_entity
+      render json: { message: "Please see administrator for creating new wine listings" }
     end
   end
 
   # PATCH/PUT /wine_listings/1
   def update
-    if @wine_listing.update(wine_listing_params)
-      render json: @wine_listing
-    else
-      render json: @wine_listing.errors, status: :unprocessable_entity
-    end
+    
+      if @wine_listing.update(wine_listing_params)
+        render json: @wine_listing
+      else
+        render json: @wine_listing.errors, status: :unprocessable_entity
+      end
   end
 
   # DELETE /wine_listings/1

--- a/app/controllers/wine_listings_controller.rb
+++ b/app/controllers/wine_listings_controller.rb
@@ -41,17 +41,22 @@ class WineListingsController < ApplicationController
   def update
 
     if current_user.admin? &&
-      @wine_listing = WineListing.update(wine_listing_params)
+      @wine_listing = WineListing.find(params[:id]).update(wine_listing_params)
         render json: @wine_listing
     else
       render json: @wine_listing.errors, status: :unprocessable_entity
     end
-
   end
 
   # DELETE /wine_listings/:id
   def destroy
-    @wine_listing.destroy
+    # @wine_listing.destroy
+    if current_user.admin? &&
+      @wine_listing.destroy
+        render json: @wine_listing
+    else
+      
+    end
   end
 
   private

--- a/app/controllers/wine_listings_controller.rb
+++ b/app/controllers/wine_listings_controller.rb
@@ -1,6 +1,7 @@
 class WineListingsController < ApplicationController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
-  before_action :set_wine_listing, only: [:show, :update, :destroy]
+  #before_action :set_wine_listing, only: [:show, :update, :destroy]
+  before_action :set_wine_listing, only: [:show, :destroy]
 
   # GET /wine_listings
   def index
@@ -36,17 +37,19 @@ class WineListingsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /wine_listings/1
+  # PUT /wine_listings/:id
   def update
-    
-      if @wine_listing.update(wine_listing_params)
+
+    if current_user.admin? &&
+      @wine_listing = WineListing.update(wine_listing_params)
         render json: @wine_listing
-      else
-        render json: @wine_listing.errors, status: :unprocessable_entity
-      end
+    else
+      render json: @wine_listing.errors, status: :unprocessable_entity
+    end
+
   end
 
-  # DELETE /wine_listings/1
+  # DELETE /wine_listings/:id
   def destroy
     @wine_listing.destroy
   end

--- a/app/controllers/wine_listings_controller.rb
+++ b/app/controllers/wine_listings_controller.rb
@@ -50,12 +50,11 @@ class WineListingsController < ApplicationController
 
   # DELETE /wine_listings/:id
   def destroy
-    # @wine_listing.destroy
     if current_user.admin? &&
-      @wine_listing.destroy
-        render json: @wine_listing
+      @wine_listing = WineListing.find(params[:id]).destroy
+        render json: { message: "Wine listing deleted!" }
     else
-      
+      render json: @wine_listing.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :comments
   has_many :wine_listings, through: :comments
 
-  def make_admin!
-    self.update_attribute(:admin, true)
-  end
+  # def make_admin!
+  #   self.update_attribute(:admin, true)
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,8 @@ class User < ApplicationRecord
   # validates :email, presence: true, uniqueness: true
   has_many :comments
   has_many :wine_listings, through: :comments
+
+  def make_admin!
+    self.update_attribute(:admin, true)
+  end
 end

--- a/client.http
+++ b/client.http
@@ -70,15 +70,17 @@ Content-Type: application/json
     "description": "test for successfully updating id: 6"
 }
 
-### Currentlty testing
-### Test Admin params performing updates to wine listing id: 2
+### !!!Test Failed!!!
+### Currently Testing UPDATE for Admin
+### Test as Admin user with params performing updates to wine listing id: 2
 ### Test inlcudes jwt
-PUT http://localhost:4000/api/wine_listings/2
+### Test only updating listings with arguement provides
+PUT http://localhost:4000/api/wine_listings/3
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0NzE0MCwiZXhwIjoxNjU5NDMzNTQwLCJqdGkiOiJmOTA3MDRmNS0zNTU2LTRkNTMtYTQ4Yi0zOTIwZTA5MTg1OTUifQ.ApqIL1iP5yc3CVFJ4nGB7gN9xnW_AFEydpbhx8cftao
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM1NDA2NiwiZXhwIjoxNjU5NDQwNDY2LCJqdGkiOiJjOGE0YTI0Mi1hZTY0LTQyZDMtYjI1YS04MjAzYzU1ODQxMjMifQ.BImjf2-sLtZTJvAVqHq0jk9tXDKrFxPjEMQfImJknLI
 
 {
-    "brand": "test for successfully updating id:2, as an admin with correct params & JWT",
+    "brand": "test for successfully updating id:3 ONLY, as an admin with correct params & JWT",
     "grape_variety": "test update id 2",
     "year": "2022",
     "category": "test update id 2",
@@ -104,13 +106,14 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
     "description": "test"
 }
 
-### Currently testing
+### NEEDS testing
+### As a regular user
 PUT http://localhost:4000/api/wine_listings/4
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
 
 {
-    "brand": "test for updating id: 4, with Auth bearer token as a regular user",
+    "brand": "test for updating id: 4, with Auth bearer token as a regular user. expect to fail",
     "grape_variety": "test",
     "year": "2022",
     "category": "test",
@@ -119,12 +122,13 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
     "description": "test"
 }
 
-
-### Sucessfully delete wine_listings id: 7
-### Currently able to delete without Authorization Bearer of secret key
+### Currently Testing for Admin to delete wine listing id 2
+### Sucessfully delete wine_listings id: 2
+### !!!Currently able to delete without Authorization Bearer of secret key!!!
 ### Response = 204 :no_content
-DELETE http://localhost:4000/api/wine_listings/7
-# Authorization: Bearer 
+DELETE http://localhost:4000/api/wine_listings/2
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM1NDQwNSwiZXhwIjoxNjU5NDQwODA1LCJqdGkiOiI3MTFjYTUwZS0yZWQ3LTRhZmItOWRkMy1hZmI2ODdjYjNiMGUifQ.Xs3b5HqUBKxZT3BHJoll4n-WuIaLCY8TRqOgOA5KR2U
 
 ### Intentionally, Unsucessfully delete wine_listings id: 1000
 ### Response = 500 :internal_server_error
@@ -181,7 +185,7 @@ Content-Type: application/json
 ### PASS with token from the login session
 DELETE http://localhost:4000/api/logout
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0OTQzNSwiZXhwIjoxNjU5NDM1ODM1LCJqdGkiOiJlNjhmNmRiMS02NDQ4LTRlNjktODQyMC0yNTg3M2YyNzgxNWMifQ.YwTrhbgg_P3UoPzC6cHWQRNlezC5xuXrw1QOBJgPlOQ
 
 ### Test for current user is admin?
 ### This test might need to be ran with rspec
@@ -189,18 +193,6 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
 
 
 ###Not yet tested
-
-### Unsuccessfully login without JWT
-### NOT PASSING!!!
-POST http://localhost:4000/users/sign_in
-Content-Type: application/json
-
-{
-    "email": "nga2@test.com",
-    "password": "password2"
-}
-
-### CURRENTLY TESTING...
 
 ### ADMIN section
 

--- a/client.http
+++ b/client.http
@@ -9,11 +9,11 @@ GET http://localhost:4000/api/wine_listings
 ### Currently creating without Authorization Bearer and Secret Key
 POST http://localhost:4000/api/wine_listings
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjU5MzM3NjQ4LCJleHAiOjE2NTk0MjQwNDgsImp0aSI6IjVjNzI2NmQ5LTNjOTQtNGUxZS05YTUwLTExY2JiMTk3NjgwZSJ9.dDnbm1E2xouB1f3c-7OzMa7lP1A0sipfI0sina2kkQQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2MTY1NywiZXhwIjoxNjU5NDQ4MDU3LCJqdGkiOiIzYzM1MDg0YS0zMWU3LTRiMDItODMzNS0wYTkzOGYxODMxZDYifQ.vwQK9pe5hixTcL2MxrMGfmnCCQXgh4eghLY9VG14Jns
 
 {
-    "brand": "Testing Admin params to create new wines. This is expected to succeed",
-    "grape_variety": "Pinot Noir",
+    "brand": "Testing Wine id 6",
+    "grape_variety": "Testing Wine id 6",
     "year": "2020",
     "category": "Red",
     "country": "Australia",
@@ -70,11 +70,10 @@ Content-Type: application/json
     "description": "test for successfully updating id: 6"
 }
 
-### !!!Test Failed!!!
-### Currently Testing UPDATE for Admin
-### Test as Admin user with params performing updates to wine listing id: 2
+
+### Testing UPDATE for Admin
+### Test as Admin user with params performing updates to wine listing id:
 ### Test inlcudes jwt
-### Test only updating listings with arguement provides
 PUT http://localhost:4000/api/wine_listings/3
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM1NDA2NiwiZXhwIjoxNjU5NDQwNDY2LCJqdGkiOiJjOGE0YTI0Mi1hZTY0LTQyZDMtYjI1YS04MjAzYzU1ODQxMjMifQ.BImjf2-sLtZTJvAVqHq0jk9tXDKrFxPjEMQfImJknLI
@@ -107,7 +106,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
 }
 
 ### NEEDS testing
-### As a regular user
+### As a regular user attempting to update wine_listing id 4
 PUT http://localhost:4000/api/wine_listings/4
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
@@ -122,13 +121,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
     "description": "test"
 }
 
-### Currently Testing for Admin to delete wine listing id 2
-### Sucessfully delete wine_listings id: 2
+### Currently Testing for Admin to delete wine listing id
 ### !!!Currently able to delete without Authorization Bearer of secret key!!!
 ### Response = 204 :no_content
-DELETE http://localhost:4000/api/wine_listings/2
+DELETE http://localhost:4000/api/wine_listings/7
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM1NDQwNSwiZXhwIjoxNjU5NDQwODA1LCJqdGkiOiI3MTFjYTUwZS0yZWQ3LTRhZmItOWRkMy1hZmI2ODdjYjNiMGUifQ.Xs3b5HqUBKxZT3BHJoll4n-WuIaLCY8TRqOgOA5KR2U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2MTY1NywiZXhwIjoxNjU5NDQ4MDU3LCJqdGkiOiIzYzM1MDg0YS0zMWU3LTRiMDItODMzNS0wYTkzOGYxODMxZDYifQ.vwQK9pe5hixTcL2MxrMGfmnCCQXgh4eghLY9VG14Jns
 
 ### Intentionally, Unsucessfully delete wine_listings id: 1000
 ### Response = 500 :internal_server_error

--- a/client.http
+++ b/client.http
@@ -6,14 +6,14 @@ GET http://localhost:4000/api/wine_listings
 
 ### Successfully creates a wine listing
 ### Response = 201 Created
-### Currently creating without Authorization Bearer and Secret Key
+
 POST http://localhost:4000/api/wine_listings
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2MTY1NywiZXhwIjoxNjU5NDQ4MDU3LCJqdGkiOiIzYzM1MDg0YS0zMWU3LTRiMDItODMzNS0wYTkzOGYxODMxZDYifQ.vwQK9pe5hixTcL2MxrMGfmnCCQXgh4eghLY9VG14Jns
+# Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2MTY1NywiZXhwIjoxNjU5NDQ4MDU3LCJqdGkiOiIzYzM1MDg0YS0zMWU3LTRiMDItODMzNS0wYTkzOGYxODMxZDYifQ.vwQK9pe5hixTcL2MxrMGfmnCCQXgh4eghLY9VG14Jns
 
 {
-    "brand": "Testing Wine id 6",
-    "grape_variety": "Testing Wine id 6",
+    "brand": "Testing Wine id 8",
+    "grape_variety": "Testing Wine id 8",
     "year": "2020",
     "category": "Red",
     "country": "Australia",
@@ -22,9 +22,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhd
 }
 
 ### Testing for regular users trying to create wine listing when not allowed because regular user does not have same rights as admin users
+### JWT below was given when a regular user logged in
 POST http://localhost:4000/api/wine_listings
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTMzNzgyNywiZXhwIjoxNjU5NDI0MjI3LCJqdGkiOiJiNjdiZTAzMi1lZmE3LTRhYzctYTQzNy00Yzk1NmI2ZGM5ZDcifQ.2xS342HCJfwLpTHp_I8FLaOQqIJLRw_7TXoG3tZ3kfc
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMiIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2NDcwNywiZXhwIjoxNjU5NDUxMTA3LCJqdGkiOiI3NjMwNDhjNC0yMTUxLTQwY2ItODFlZS1jZDgwNWIyOTAyYzIifQ.Jqs21IjodMTJXzpag--NOmF0x_Eq91nj1Kk7V4TCE8g
 
 {
     "brand": "Testing for regular using trying to create wine listing when not allowed because regular user does not have same rights as admin users. This should fail",
@@ -54,9 +55,9 @@ GET http://localhost:4000/api/wine_listings/2
 ### Response = 404 Not Found
 GET http://localhost:4000/api/wine_listings/1000
 
-### Succesfully update wine_listing id: 6
-### Response = 200 OK , provided all fields are given with valid entries.
-### Currently works without Authorization: Bearer IXtQvVtEdHw0LVZ3ajJxYZmM2lxH5poEx5ehvz+I9zZXt16j8bsAa+iBGDfsmg4a91O3xHFB5Csr3/56wo8VWGwHpHM8G+nGjkPVE5L9a/z/k9yLuJVFzX+DWk5eocxF+O21oGwZHRpX6IV1qpwz2q2wTqgunBOLytYuiGYgEw8aQQ2efuwxESVEXsu8WltnSUgs9haT7BGAQ5TjAmbPYbHnwm4Mk6LJ+HXDkf1Oe9Ql9KdSu2H1pPG3p7d8Men94qQcAA2yWSY05+ffU742An4op7RJIlNKnxef7ykpLeSkuu5euX56YlGE6A7W1TLQGoFdaSieogBU8rCJStza3t05cEQtQKuxbOaSvM13b++eIbfPBMDrfo+G1BLai3Hzt1oB/l7mHN/WhFXOsz3nlf9Mmcs3wT5MKEq1--/HzZNlkEjUZvKWmu--L6jB9wXfmTcENo7wDpVOig==
+### The purpose of this test is to ensure that user must be logged in as Admin to be able to UPDATE wine listings
+### Response = 401 Unauthorized
+### Currently DOES NOT work without Authorization: Bearer 
 PUT http://localhost:4000/api/wine_listings/6
 Content-Type: application/json
 
@@ -159,8 +160,8 @@ Content-Type: application/json
 
 {  
     "user": {
-        "username": "Username2",
-        "email": "Username2@test.com",
+        "username": "Username3",
+        "email": "Username3@test.com",
         "password": "password",
         "password_confirmation": "password"
     }
@@ -174,8 +175,10 @@ Content-Type: application/json
 
 {  
     "user": {
-        "email": "testadmin@test.com",
-        "password": "adminpw1"
+        "username": "Username3",
+        "email": "Username3@test.com",
+        "password": "password",
+        "password_confirmation": "password"
     }
 }
 
@@ -183,7 +186,7 @@ Content-Type: application/json
 ### PASS with token from the login session
 DELETE http://localhost:4000/api/logout
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0OTQzNSwiZXhwIjoxNjU5NDM1ODM1LCJqdGkiOiJlNjhmNmRiMS02NDQ4LTRlNjktODQyMC0yNTg3M2YyNzgxNWMifQ.YwTrhbgg_P3UoPzC6cHWQRNlezC5xuXrw1QOBJgPlOQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM2MTY1NywiZXhwIjoxNjU5NDQ4MDU3LCJqdGkiOiIzYzM1MDg0YS0zMWU3LTRiMDItODMzNS0wYTkzOGYxODMxZDYifQ.vwQK9pe5hixTcL2MxrMGfmnCCQXgh4eghLY9VG14Jns
 
 ### Test for current user is admin?
 ### This test might need to be ran with rspec

--- a/client.http
+++ b/client.http
@@ -9,16 +9,31 @@ GET http://localhost:4000/api/wine_listings
 ### Currently creating without Authorization Bearer and Secret Key
 POST http://localhost:4000/api/wine_listings
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxNCIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTE1NDQwMCwiZXhwIjoxNjYwNDUwNDAwLCJqdGkiOiI0ZmQ5ODVjYy0yZTFiLTQyYWEtODczMC1jODkwYTljZjVmODUifQ.-Iu3jFbybuPpIch9FHx8mYQEU8vmoR7e_-sv8e2dZ7k
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjU5MzM3NjQ4LCJleHAiOjE2NTk0MjQwNDgsImp0aSI6IjVjNzI2NmQ5LTNjOTQtNGUxZS05YTUwLTExY2JiMTk3NjgwZSJ9.dDnbm1E2xouB1f3c-7OzMa7lP1A0sipfI0sina2kkQQ
 
 {
-    "brand": "Wine By Farr",
+    "brand": "Testing Admin params to create new wines. This is expected to succeed",
     "grape_variety": "Pinot Noir",
     "year": "2020",
     "category": "Red",
     "country": "Australia",
     "region": "Geelong",
     "description": "Great deep colour, and sweet spice aromas, with a much firmer palate than we see in the Sangreal. These wines have a perfect fade from fruit to structure, a velvet like character, really complex texture. It’s darker, firmer edged and more upright. You can taste a fresher fruit note, black cherries and plums and a sense of fine oak. Really impressive."
+}
+
+### Testing for regular users trying to create wine listing when not allowed because regular user does not have same rights as admin users
+POST http://localhost:4000/api/wine_listings
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTMzNzgyNywiZXhwIjoxNjU5NDI0MjI3LCJqdGkiOiJiNjdiZTAzMi1lZmE3LTRhYzctYTQzNy00Yzk1NmI2ZGM5ZDcifQ.2xS342HCJfwLpTHp_I8FLaOQqIJLRw_7TXoG3tZ3kfc
+
+{
+    "brand": "Testing for regular using trying to create wine listing when not allowed because regular user does not have same rights as admin users. This should fail",
+    "grape_variety": "Pinot Noir",
+    "year": "2020",
+    "category": "Red",
+    "country": "Australia",
+    "region": "Geelong",
+    "description": "description for testing purposes only."
 }
 
 ### Unsuccessfully posts a wine_listing.
@@ -108,7 +123,7 @@ POST http://localhost:4000/api/login
 Content-Type: application/json
 
 {  
-   "user": {
+    "user": {
         "username": "Username2",
         "email": "Username2@test.com",
         "password": "password",
@@ -120,7 +135,7 @@ Content-Type: application/json
 ### PASS with token from the login session
 DELETE http://localhost:4000/api/logout
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTI0MjM1MSwiZXhwIjoxNjU5MzI4NzUxLCJqdGkiOiIwYWVkYTBmNC1kNjA0LTRmODUtOTU0Zi05NzVmNTcwMGE2YTkifQ.Qt5jIiRJzM_oFn0yBIrmRssva3ix2biXcwo1BWHtAIQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjU5MzM3NjQ4LCJleHAiOjE2NTk0MjQwNDgsImp0aSI6IjVjNzI2NmQ5LTNjOTQtNGUxZS05YTUwLTExY2JiMTk3NjgwZSJ9.dDnbm1E2xouB1f3c-7OzMa7lP1A0sipfI0sina2kkQQ
 
 ### Test for current user is admin?
 ### This test might need to be ran with rspec

--- a/client.http
+++ b/client.http
@@ -70,6 +70,55 @@ Content-Type: application/json
     "description": "test for successfully updating id: 6"
 }
 
+### Currentlty testing
+### Test Admin params performing updates to wine listing id: 2
+### Test inlcudes jwt
+PUT http://localhost:4000/api/wine_listings/2
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0NzE0MCwiZXhwIjoxNjU5NDMzNTQwLCJqdGkiOiJmOTA3MDRmNS0zNTU2LTRkNTMtYTQ4Yi0zOTIwZTA5MTg1OTUifQ.ApqIL1iP5yc3CVFJ4nGB7gN9xnW_AFEydpbhx8cftao
+
+{
+    "brand": "test for successfully updating id:2, as an admin with correct params & JWT",
+    "grape_variety": "test update id 2",
+    "year": "2022",
+    "category": "test update id 2",
+    "country": "test update id 2",
+    "region": "test update id 2",
+    "description": "test update id 2"
+}
+
+### Successful testing of
+### a fail attempt for regular user, who is logged in, performing an update of wine listings
+### response = 204 No Content
+PUT http://localhost:4000/api/wine_listings/4
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
+
+{
+    "brand": "test for updating id: 4, with Auth bearer token as a regular user. This is expected to fail",
+    "grape_variety": "test",
+    "year": "2022",
+    "category": "test",
+    "country": "test",
+    "region": "test",
+    "description": "test"
+}
+
+### Currently testing
+PUT http://localhost:4000/api/wine_listings/4
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
+
+{
+    "brand": "test for updating id: 4, with Auth bearer token as a regular user",
+    "grape_variety": "test",
+    "year": "2022",
+    "category": "test",
+    "country": "test",
+    "region": "test",
+    "description": "test"
+}
+
 
 ### Sucessfully delete wine_listings id: 7
 ### Currently able to delete without Authorization Bearer of secret key
@@ -89,21 +138,20 @@ GET http://localhost:4000/member-data
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjU4NTYwMTU3LCJleHAiOjE2NTg1NjM3NTcsImp0aSI6IjkxNjRlNzY1LTAwMzktNDk2Ny1hZWI5LTJkYjc3OTgyOGI0NyJ9.MeM_CqfGUUuk8N1nKRowKbDEEcNBsMtfqWg_A4QBs9s
 
-
-### Create user
-### params email and password
+### THIS TEST IS NOT WORKING AS EXPECTED!!!
+### Create user with only 2 params - email and password - Should FAIL
 POST http://localhost:4000/api/sign_up
 Content-Type: application/json
 
 {  
     "user": {
-        "email": "me10@test.com",
+        "email": "2params@test.com",
         "password": "password10"
     }
 }
 
 ### Create user
-### Params username, email, password
+### 4 Params given - username, email, password, password_confirmation
 POST http://localhost:4000/api/sign_up
 Content-Type: application/json
 
@@ -124,10 +172,8 @@ Content-Type: application/json
 
 {  
     "user": {
-        "username": "Username2",
-        "email": "Username2@test.com",
-        "password": "password",
-        "password_confirmation": "password"
+        "email": "testadmin@test.com",
+        "password": "adminpw1"
     }
 }
 
@@ -135,7 +181,7 @@ Content-Type: application/json
 ### PASS with token from the login session
 DELETE http://localhost:4000/api/logout
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NwIjoidXNlciIsImF1ZCI6bnVsbCwiaWF0IjoxNjU5MzM3NjQ4LCJleHAiOjE2NTk0MjQwNDgsImp0aSI6IjVjNzI2NmQ5LTNjOTQtNGUxZS05YTUwLTExY2JiMTk3NjgwZSJ9.dDnbm1E2xouB1f3c-7OzMa7lP1A0sipfI0sina2kkQQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMSIsInNjcCI6InVzZXIiLCJhdWQiOm51bGwsImlhdCI6MTY1OTM0MjU3MywiZXhwIjoxNjU5NDI4OTczLCJqdGkiOiIxMTI4ZTI5My02NDE0LTRhZTctYTY2NC1jNWUxOTJhODM1YjAifQ.R5JhlDBx35rDxjll7ZzAp-3BvKeBLBwpVY5WMLMghhg
 
 ### Test for current user is admin?
 ### This test might need to be ran with rspec


### PR DESCRIPTION
- Changes made in wine_listings controllers to allow Admin role to CREATE, UPDATE & DELETE.
- Please note that deleting wine listings require that a wine_listing does not have any associations with comments. The way around this at the moment, is that admin will need to remove all comments first before deleting the wine_listings.
- I have ran more tests from the client.http files to ensure the above features are true. In addition, I have checked that regular users cannot create, update and delete wine_listing. I have also checked that Auth. Bearer must be provided to perform these task by the admin role.