### PR TITLE
return user data at login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,7 +4,7 @@ class Users::SessionsController < Devise::SessionsController
   private
 
   def respond_with(resource, _opts = {})
-    render json: { message: "You are logged in." }, status: :ok
+    render json: { user: current_user }, status: :ok
   end
 
   def respond_to_on_destroy


### PR DESCRIPTION
change return when users login that API responds with current_user data.
Essential for successful login and storing the username in sessionStorage 
This was supposed to be in the previous PR, and this is essential so pushing this one line change.